### PR TITLE
feat: consolidate template comment snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ All snippets use the `pt` prefix (short for "Python Template"). Here's the compl
 | `ptvar` | Template variable | `{{ variable }}` |
 | `ptfilt` | Variable with filter | `{{ variable \| filter }}` |
 | `ptcode` | Code block tag | `{% code %}` |
+| `ptcom` | Comment | `{# comment #}` |
 | `ptblock` | Block tag | `{% block name %}...{% endblock %}` |
 | `ptext` | Extends tag | `{% extends 'base.html' %}` |
 | `ptsup` | Super function | `{{ super() }}` |
@@ -108,7 +109,6 @@ All snippets use the `pt` prefix (short for "Python Template"). Here's the compl
 |--------|-------------|---------|
 | `ptj-url` | Static file URL | `{{ url_for('static', filename='file.css') }}` |
 | `ptj-mac` | Macro definition | `{% macro name %}...{% endmacro %}` |
-| `ptj-com` | Comment | `{# comment #}` |
 | `ptj-set` | Set variable | `{% set var = value %}` |
 
 ### 🎨 Django-Specific Snippets

--- a/snippets/jinja-snippets.json
+++ b/snippets/jinja-snippets.json
@@ -19,14 +19,6 @@
 		"description": "Adds macro tags"
 	},
 
-	"Jinja - Comments": {
-		"scope": "html",
-		"prefix": "ptj-com",
-		"body": [
-			"{# $0 #}"
-		],
-		"description": "Adds Jinja comment"
-	},
 	"Jinja - Set Variable": {
 		"scope": "html",
 		"prefix": "ptj-set",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -42,6 +42,15 @@
 		"description": "Adds code block tags"
 	},
 
+	"Template Comment": {
+		"scope": "html",
+		"prefix": "ptcom",
+		"body": [
+			"{# $0 #}"
+		],
+		"description": "Adds template comment tag"
+	},
+
 	"Template Block Tag": {
 		"scope": "html",
 		"prefix": "ptblock",


### PR DESCRIPTION
## Summary
- add a shared `ptcom` template comment snippet to the general catalog
- remove the Jinja-only `ptj-com` snippet
- update README snippet tables to reflect the new shared prefix

Closes #47
